### PR TITLE
Do not use depracated APIs

### DIFF
--- a/keymaps/atom-terminal.cson
+++ b/keymaps/atom-terminal.cson
@@ -7,6 +7,6 @@
 
 # For more detailed documentation see
 # https://atom.io/docs/latest/advanced/keymaps
-'.workspace':
+'atom-workspace':
     'ctrl-shift-t': 'atom-terminal:open'
     'alt-shift-t': 'atom-terminal:open-project-root'

--- a/lib/atom-terminal.coffee
+++ b/lib/atom-terminal.coffee
@@ -42,17 +42,19 @@ open_terminal = (dirpath) ->
 
 module.exports =
     activate: ->
-        atom.workspaceView.command "atom-terminal:open", => @open()
-        atom.workspaceView.command "atom-terminal:open-project-root", => @openroot()
+        atom.commands.add "atom-workspace", "atom-terminal:open", => @open()
+        atom.commands.add "atom-workspace", "atom-terminal:open-project-root", => @openroot()
     open: ->
         editor = atom.workspace.getActivePaneItem()
-        file = editor?.buffer.file
+        file = editor?.buffer?.file
         filepath = file?.path
         if filepath
             open_terminal path.dirname(filepath)
+        else
+            @openroot
+
     openroot: ->
-        if atom.project.path
-            open_terminal atom.project.path
+        open_terminal path for path in atom.project.getPaths()
 
 # Set per-platform defaults
 if platform() == 'darwin'


### PR DESCRIPTION
In this pull request, I have removed the calls to deprecated APIs (this should fix issue #22). 

In the process I have added support for multi-directory projects (one terminal is opened for each folder). The multi-directory projects feature is yet to be implemented in atom but already present in the API. 

Furthermore I have added code to fallback to open-project-root when no file is open. This adresses issue #19. 

Note: This pull request also includes pull request #21 (which fixes #20). (/cc @pwielgolaski)