### PR TITLE
Added a way to send the dirpath along the args

### DIFF
--- a/lib/atom-terminal.coffee
+++ b/lib/atom-terminal.coffee
@@ -9,6 +9,9 @@ open_terminal = (dirpath) ->
   # Figure out the app and the arguments
   app = atom.config.get('atom-terminal.app')
   args = atom.config.get('atom-terminal.args')
+   
+   # Adds the dirpath to the args if the pattern "[dirpath]" is found
+  args = args.replace /\[dirpath\]/, dirpath
 
   # get options
   setWorkingDirectory = atom.config.get('atom-terminal.setWorkingDirectory')


### PR DESCRIPTION
Added a way to send the dirpath along the args. If you put the pattern "[dirpath]" in the arguments, this modification will make it replace that pattern with the dirpath variable.

This is useful if you use a cmd that is not the default, and you have to supply the current working directory at the arguments (that's the case with Cmder, for example).